### PR TITLE
PERSONA-15 fix: CORS setAllowed Origin 패턴 도메인을 개별적으로 추가

### DIFF
--- a/src/main/java/GDG4th/personaChat/global/configurer/SecurityConfig.java
+++ b/src/main/java/GDG4th/personaChat/global/configurer/SecurityConfig.java
@@ -1,9 +1,8 @@
 package GDG4th.personaChat.global.configurer;
 
-import org.springframework.beans.factory.annotation.Value;
+import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -13,8 +12,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-
-import java.util.List;
 
 @Configuration
 public class SecurityConfig {
@@ -40,11 +37,9 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
 
-        config.setAllowedOriginPatterns(List.of("*"));
+        config.setAllowedOriginPatterns(List.of("http://localhost:5173","https://personachat.my"));
         // 허용할 HTTP 메서드 설정
-        config.setAllowedMethods(List.of(HttpMethod.GET.name(), HttpMethod.POST.name(),
-                HttpMethod.PATCH.name(), HttpMethod.DELETE.name(),
-                HttpMethod.OPTIONS.name()));
+        config.setAllowedMethods(List.of("GET", "POST", "PATCH", "DELETE", "OPTIONS"));
 
         // 허용할 요청 헤더 설정
         config.setAllowedHeaders(List.of("Authorization", "Content-Type"));

--- a/src/main/java/GDG4th/personaChat/global/configurer/WebConfig.java
+++ b/src/main/java/GDG4th/personaChat/global/configurer/WebConfig.java
@@ -19,13 +19,6 @@ public class WebConfig implements WebMvcConfigurer {
     private final SessionUserIdArgumentResolver sessionUserIdArgumentResolver;
 
     @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOriginPatterns("*")
-                .allowedMethods("GET", "POST", "PATCH", "DELETE", "OPTIONS");
-    }
-
-    @Override
     public void addInterceptors(InterceptorRegistry registry){
         registry.addInterceptor(sessionInterceptor);
     }

--- a/src/main/java/GDG4th/personaChat/global/util/CookieUtil.java
+++ b/src/main/java/GDG4th/personaChat/global/util/CookieUtil.java
@@ -26,7 +26,7 @@ public class CookieUtil {
         Cookie cookie = new Cookie(name, value);
         cookie.setPath("/"); // 모든 경로에서 사용 가능
         cookie.setHttpOnly(true); // JavaScript 접근 방지 (XSS 공격 방지)
-        cookie.setSecure(true); // HTTPS에서만 쿠키 전송
+        cookie.setSecure(false); // HTTPS에서만 쿠키 전송
         cookie.setMaxAge(maxAge); // 만료 시간 설정
         response.addCookie(cookie);
     }


### PR DESCRIPTION
## PR 제목

### 구현 내용
- CORS setAllowed Origin 패턴 도메인을 개별적으로 추가
---

### 구현 이유
- CORS 설정에서 setOriginPattern을 와일드카드로 설정 시 credential 포함된 요청을 수행할 수 없는 문제를 발견해서 따로 도메인을 지정해주었습니다
---

### 버그 리포트